### PR TITLE
[Feat/#9] next.revalidate 옵션으로인한 Server Components 렌더링 에러 발생

### DIFF
--- a/src/app/packages/[...package_name]/(components)/PackageDetail.tsx
+++ b/src/app/packages/[...package_name]/(components)/PackageDetail.tsx
@@ -20,8 +20,7 @@ export async function PackageDetail({ packageName }: Props) {
 
 async function getPackageJSON(packageName: string): Promise<PackageVersion> {
   const response = await fetch(
-    `${process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000"}/api/packages/${encodeURIComponent(packageName)}`,
-    { next: { revalidate: 3600 } }
+    `${process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000"}/api/packages/${encodeURIComponent(packageName)}`
   );
 
   if (response.status === 404) {

--- a/src/components/DependencyCombinationTreeMapChart.tsx
+++ b/src/components/DependencyCombinationTreeMapChart.tsx
@@ -40,8 +40,7 @@ export function DependencyCombinationTreeMapChart({ packageName }: { packageName
 
 async function getPackageDependencySizes(packageName: string): Promise<PackageSize> {
   const response = await fetch(
-    `${process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000"}/api/packages/${encodeURIComponent(packageName)}/size`,
-    { next: { revalidate: 3600 } }
+    `${process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000"}/api/packages/${encodeURIComponent(packageName)}/size`
   );
 
   if (response.status === 404) {


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [x] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 📝 PR 설명
기존의 명시적 revalidate 설정이 Server Components 렌더링 에러를 발생시키고 있었습니다. 
이를 해결하기 위해 불필요한 캐시 옵션을 제거하고 기본값을 사용하도록 변경했습니다.
<!-- PR 설명 -->

## 관련된 이슈 넘버
close #9 
<!-- close #1 -->

## ✅ 작업 목록
-  모든 fetch 요청에서 { next: { revalidate: xxx } } 옵션 제거
<!-- 이슈 작업한 내용 -->

## MR하기 전에 확인해주세요

- [ ] local code lint 검사를 진행하셨나요?
- [ ] loca ci test를 진행하셨나요?

## 📚 논의사항
```ts
// AS IS
const data = await fetch('/api/data', {
  next: { revalidate: 3600 }
})
// TO BE
const data = await fetch('/api/data')
```
<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC

<!-- Screenshot, References 기재 -->